### PR TITLE
Fixed APScheduler requirement so PIP installs the correct version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ requests==2.2.1
 six==1.6.1
 urllib3==1.8
 wsgiref==0.1.2
-apscheduler
+apscheduler==2.1.2
 setproctitle
 decorator


### PR DESCRIPTION
APScheduler has to be version 2.1.2, and it being unspecified in the requirements.txt automatically installs 3.0.0, which has huge architectural changes causing it not to work.
